### PR TITLE
Update example_mandelbrot.ipynb

### DIFF
--- a/mandelbrot/example_mandelbrot.ipynb
+++ b/mandelbrot/example_mandelbrot.ipynb
@@ -20,7 +20,7 @@
     "from math import sqrt\n",
     "from matplotlib import colors\n",
     "from matplotlib import pyplot as plt\n",
-    "from cloudbutton.multiprocessing import Pool\n",
+    "from lithops.multiprocessing import Pool\n",
     "\n",
     "%matplotlib notebook"
    ]


### PR DESCRIPTION
I believe that `cloudbutton` import was broken and should be a `lithops` import.